### PR TITLE
menu-item overlapping issue

### DIFF
--- a/src/components/Menu/MenuItem/MenuItem.scss
+++ b/src/components/Menu/MenuItem/MenuItem.scss
@@ -2,6 +2,7 @@
     position: fixed;
     top: 50%;
     left: 2em;
+    background-color: var(--bg-primary);
     transform: translateY(-50%);
     visibility: hidden;
     opacity: 0;
@@ -11,7 +12,14 @@
         font-size: 2em;
     }
 }
-
+.dark-mode {
+  .menu-item {
+    background-color: var(--bg-primary);
+  }
+  .menu-item:hover {
+    background-color: var(--text-primary);
+  }
+}
 .menu-active {
     .menu-item {
         visibility: visible;


### PR DESCRIPTION
On overlapping the menu-items doesn't clearly visible. I have added some standard background colors to make the menu-items visible properly in both light and dark modes.